### PR TITLE
fix type from string to fix random date being set

### DIFF
--- a/LocalToUtc/LocalToUtc.psm1
+++ b/LocalToUtc/LocalToUtc.psm1
@@ -152,7 +152,7 @@ function IsVerbose ([Switch] $Verbose) {
 
 function Get-InputTime {
     Param (
-        [String] $Time,
+        [datetime] $Time,
         [Int] $AddDays,
         [Int] $AddHours,
         [Int] $AddMinutes

--- a/LocalToUtc/LocalToUtc.psm1
+++ b/LocalToUtc/LocalToUtc.psm1
@@ -152,7 +152,7 @@ function IsVerbose ([Switch] $Verbose) {
 
 function Get-InputTime {
     Param (
-        [datetime] $Time,
+        [DateTime] $Time,
         [Int] $AddDays,
         [Int] $AddHours,
         [Int] $AddMinutes


### PR DESCRIPTION
Hi,
Found an issue when using `Convert-LocalToUtc` with no params being set. Instead of using the current date time, it was picking 10 August 2019.
Updated the var type in `get-inputTime` and that seems to have fixed it. (I hope!)